### PR TITLE
Fix uncompletable kill quests by adding required enemy spawns

### DIFF
--- a/rpg/world.py
+++ b/rpg/world.py
@@ -19,6 +19,8 @@ def create_world() -> dict[str, Location]:
         exits={"south": "town_square", "north": "ruined_watchtower"},
         enemies=[
             Enemy("Wolf", 30, 8, 2, 20, 12, "A hungry gray wolf."),
+            Enemy("Wolf", 30, 8, 2, 20, 12, "A hungry gray wolf."),
+            Enemy("Wolf", 30, 8, 2, 20, 12, "A hungry gray wolf."),
             Enemy("Boar", 40, 9, 3, 24, 15, "A massive tusked boar."),
         ],
         items=[Item("Herb", "A medicinal herb restoring 20 HP.", value=5, heal_amount=20)],
@@ -40,7 +42,10 @@ def create_world() -> dict[str, Location]:
         name="Ruined Watchtower",
         description="A collapsed tower crawling with bandits and old treasures.",
         exits={"south": "old_forest", "east": "mountain_pass"},
-        enemies=[Enemy("Bandit", 55, 12, 4, 35, 30, "A ruthless scavenger.")],
+        enemies=[
+            Enemy("Bandit", 55, 12, 4, 35, 30, "A ruthless scavenger."),
+            Enemy("Bandit", 55, 12, 4, 35, 30, "A ruthless scavenger."),
+        ],
         items=[Item("Iron Sword", "Reliable steel blade.", value=25, attack_bonus=4)],
     )
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,4 +1,5 @@
 from rpg.game import Game
+from rpg.world import create_world
 
 
 def test_basic_movement_and_look():
@@ -36,3 +37,17 @@ def test_plugin_command_loads():
     assert "campfire_plugin" in result
     out = game.process_command("rest")
     assert "recover" in out
+
+
+def test_quest_kill_requirements_are_possible_from_world_spawns():
+    world = create_world()
+
+    enemy_counts: dict[str, int] = {}
+    for location in world.values():
+        for enemy in location.enemies:
+            enemy_counts[enemy.name] = enemy_counts.get(enemy.name, 0) + 1
+
+    for location in world.values():
+        for quest in location.quests:
+            available = enemy_counts.get(quest.target_enemy, 0)
+            assert available >= quest.required_kills


### PR DESCRIPTION
### Motivation

- Quests that require multiple kills were impossible to complete because defeated enemies are permanently removed and the world only spawned fewer enemies than the quest `required_kills` values.

### Description

- Added additional `Wolf` spawns in `old_forest` so the `Wolf Hunt` quest (`required_kills=3`) can be completed with available world spawns by adding two extra `Enemy("Wolf", ...)` entries in `rpg/world.py`.
- Added an additional `Bandit` spawn in `ruined_watchtower` so the `End the Bandits` quest (`required_kills=2`) can be completed by available world spawns by making the `enemies` list contain two `Bandit` entries in `rpg/world.py`.
- Added a regression test `test_quest_kill_requirements_are_possible_from_world_spawns` in `tests/test_game.py` which constructs the world with `create_world()`, counts enemies by name, and asserts each quest's `required_kills` is <= available spawns.

### Testing

- Ran the test suite with `python3 -m pytest -q` and all tests passed (`5 passed`).
- The new regression test verifies that every quest's `required_kills` is achievable from total world enemy spawns and succeeded under automated test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992e90b38788320bf6ff2e8bd0f7088)